### PR TITLE
Fix callback typeerror in thinker app

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1164,7 +1164,7 @@ class MainWindow:
         # UI 업데이트
         self.root.update_idletasks()
     
-    def _on_recording_stopped(self):
+    def _on_recording_stopped(self, recorded_actions: List[Dict]):
         """녹화 중지 콜백"""
         # 상태바 초기화
         self.status_label.config(text="녹화 완료")


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update `_on_recording_stopped` signature to accept `recorded_actions` argument, resolving a `TypeError`.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->

---
<a href="https://cursor.com/background-agent?bcId=bc-89857bc6-672c-457c-b1ca-ff7d7e61d471">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-89857bc6-672c-457c-b1ca-ff7d7e61d471">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>